### PR TITLE
bug(RHTAPWATCH-966): tests not compatible with EXTRA_DEPLOY_ARGS

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -112,6 +112,10 @@ spec:
       type: string
       description: "Update the ibutsu source for the current run"
       default: ""
+    - name: EXTRA_DEPLOY_ARGS
+      type: string
+      description: "Extra arguments for the deployment"
+      default: ""
 
   results:
     - name: ARTIFACTS_URL
@@ -177,6 +181,8 @@ spec:
           value: "$(params.COMPONENTS)"
         - name: COMPONENTS_W_RESOURCES
           value: "$(params.COMPONENTS_W_RESOURCES)"
+        - name: EXTRA_DEPLOY_ARGS
+          value: "$(params.EXTRA_DEPLOY_ARGS)"
       runAfter:
         - reserve-namespace
       taskRef:

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -41,6 +41,10 @@ spec:
       type: string
       description: component to keep
       default: ""
+    - name: EXTRA_DEPLOY_ARGS
+      type: string
+      description: "Extra arguments for the deployment"
+      default: ""
   steps:
     - name: deploy-application
       image: "$(params.BONFIRE_IMAGE)"
@@ -83,6 +87,8 @@ spec:
           value: $(params.SNAPSHOT)
         - name: BONFIRE_BOT
           value: "true"
+        - name: EXTRA_DEPLOY_ARGS
+          value: "$(params.EXTRA_DEPLOY_ARGS)"
       script: |
         #!/bin/bash
         set -ex
@@ -91,6 +97,10 @@ spec:
         login.sh
 
         echo "deploying to ephemeral"
-        EXTRA_DEPLOY_ARGS="$(parse-snapshot.py)"
+        if [ -z "${EXTRA_DEPLOY_ARGS}" ]; then
+          EXTRA_DEPLOY_ARGS="$(parse-snapshot.py)"
+        else
+          EXTRA_DEPLOY_ARGS+="$(parse-snapshot.py)"
+        fi
         export EXTRA_DEPLOY_ARGS
         deploy.sh "$(params.NS)" "$(params.NS_REQUESTER)" 


### PR DESCRIPTION
Adding EXTRA_DEPLOY_ARGS env variable to the basic pipeline and to the deployment.
Otherwise, tests fail because it's not compatible with EXTRA_DEPLOY_ARGS.