### PR TITLE
Add whitespace for correct bonfire command generation

### DIFF
--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -100,7 +100,7 @@ spec:
         if [ -z "${EXTRA_DEPLOY_ARGS}" ]; then
           EXTRA_DEPLOY_ARGS="$(parse-snapshot.py)"
         else
-          EXTRA_DEPLOY_ARGS+="$(parse-snapshot.py)"
+          EXTRA_DEPLOY_ARGS+=" $(parse-snapshot.py) "
         fi
         export EXTRA_DEPLOY_ARGS
         deploy.sh "$(params.NS)" "$(params.NS_REQUESTER)" 


### PR DESCRIPTION
The bonfire command generated was
```
[deploy-application] + bonfire deploy --source=appsre --ref-env insights-production --namespace ephemeral-kqywyx --timeout 900 --optional-deps-method hybrid --frontends false image-builder-crc--set-template-ref provisioning-frontend=40c2b8467381fad3591906e5feb69669eccd592e <output ommited> provisioning
```
Which is incorrect. See `image-builder-crc--set-template-ref`