### PR TITLE
Add deploy frontends key value

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -116,6 +116,10 @@ spec:
       type: string
       description: "Extra arguments for the deployment"
       default: ""
+    - name: DEPLOY_FRONTENDS
+      type: string
+      description: "Deploy frontend in the env or not"
+      default: ""
 
   results:
     - name: ARTIFACTS_URL
@@ -183,6 +187,8 @@ spec:
           value: "$(params.COMPONENTS_W_RESOURCES)"
         - name: EXTRA_DEPLOY_ARGS
           value: "$(params.EXTRA_DEPLOY_ARGS)"
+        - name: DEPLOY_FRONTENDS
+          value: "$(params.DEPLOY_FRONTENDS)"
       runAfter:
         - reserve-namespace
       taskRef:

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -45,6 +45,10 @@ spec:
       type: string
       description: "Extra arguments for the deployment"
       default: ""
+    - name: DEPLOY_FRONTENDS
+      type: string
+      description: "Deploy frontend in the env or not"
+      default: ""
   steps:
     - name: deploy-application
       image: "$(params.BONFIRE_IMAGE)"
@@ -89,6 +93,8 @@ spec:
           value: "true"
         - name: EXTRA_DEPLOY_ARGS
           value: "$(params.EXTRA_DEPLOY_ARGS)"
+        - name: DEPLOY_FRONTENDS
+          value: "$(params.DEPLOY_FRONTENDS)"
       script: |
         #!/bin/bash
         set -ex


### PR DESCRIPTION
Added DEPLOY_FRONTENDS https://github.com/redhat-appstudio/tenants-config/blob/main/cluster/stone-prd-rh01/tenants/rh-hms-tenant/provisioning-frontend-integration.yaml#L34 
But the bonfire command generated has `--frontends false`.
<img width="624" alt="Screenshot 2024-06-12 at 6 24 45 PM" src="https://github.com/RedHatInsights/bonfire-tekton/assets/38880644/ff81a0b9-0093-4d7f-a560-6164d7d41ae7">

