### PR TITLE
RHCLOUD-35642: IQE_ENV_VARS support for Konflux

### DIFF
--- a/tasks/run-iqe-cji.yaml
+++ b/tasks/run-iqe-cji.yaml
@@ -55,6 +55,10 @@ spec:
       type: string
       description: "something -- value to set for ENV_FOR_DYNACONF, default is \"clowder_smoke\""
       default: "clowder_smoke"
+    - name: IQE_ENV_VARS
+      type: string
+      description: "Comma delimited string with additional values, such as IQE_ENV_VARS='DYNACONF_USER_PROVIDER__rbac_enabled=false,foo=bar'"
+      default: ""
     - name: IQE_SELENIUM
       type: string
       description: "true -- whether to run IQE pod with a selenium container, default is false"
@@ -109,6 +113,8 @@ spec:
           value: $(params.IQE_CJI_TIMEOUT)
         - name: IQE_ENV
           value: $(params.IQE_ENV)
+        - name: IQE_ENV_VARS
+          value: $(params.IQE_ENV_VARS)
         - name: IQE_SELENIUM
           value: $(params.IQE_SELENIUM)
         - name: IQE_PARALLEL_ENABLED


### PR DESCRIPTION
This is needed to pass it in for Konflux. Related PR [here](https://github.com/RedHatInsights/cicd-tools/pull/114)