### PR TITLE
Enable IQE_IMAGE_TAG parameter for pipelines/basic

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ spec:
       value: # Ibutsu source for the current run. Default is "".
     - name: DEPLOY_TIMEOUT
       value: # Deploy timeout. Default is "900"
+    - name: IQE_IMAGE_TAG
+      value: # The IQE image used to run tests. Default is "".
 ```
 > **NOTE:** You can fork the pipeline from https://github.com/RedHatInsigths/bonfire-tekton in order to customize it. In case you do it, you will need to change the `url` field in the `IntegrationTestScenario`.
 4. Add the following `kustomization.yaml` file in the same directory:

--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -124,6 +124,10 @@ spec:
       type: string
       description: "Deploy timeout"
       default: "900"
+    - name: IQE_IMAGE_TAG
+      type: string
+      description: "Tag of the iqe image to run tests from"
+      default: ""
   results:
     - name: ARTIFACTS_URL
       description: URL for the test's artifacts
@@ -245,6 +249,8 @@ spec:
           value: "${params.IQE_RP_ARGS}"
         - name: IQE_IBUTSU_SOURCE
           value: "${params.IQE_IBUTSU_SOURCE}"
+        - name: IQE_IMAGE_TAG
+          value: "${params.IQE_IMAGE_TAG}"
       runAfter:
         - deploy-application
       taskRef:

--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -242,13 +242,13 @@ spec:
         - name: IQE_SELENIUM
           value: "$(params.IQE_SELENIUM)"
         - name: IQE_PARALLEL_ENABLED
-          value: "${params.IQE_PARALLEL_ENABLED}"
+          value: "$(params.IQE_PARALLEL_ENABLED)"
         - name: IQE_PARALLEL_WORKER_COUNT
-          value: "${params.IQE_PARALLEL_WORKER_COUNT}"
+          value: "$(params.IQE_PARALLEL_WORKER_COUNT)"
         - name: IQE_RP_ARGS
-          value: "${params.IQE_RP_ARGS}"
+          value: "$(params.IQE_RP_ARGS)"
         - name: IQE_IBUTSU_SOURCE
-          value: "${params.IQE_IBUTSU_SOURCE}"
+          value: "$(params.IQE_IBUTSU_SOURCE)"
         - name: IQE_IMAGE_TAG
           value: "$(params.IQE_IMAGE_TAG)"
       runAfter:

--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -250,7 +250,7 @@ spec:
         - name: IQE_IBUTSU_SOURCE
           value: "${params.IQE_IBUTSU_SOURCE}"
         - name: IQE_IMAGE_TAG
-          value: "${params.IQE_IMAGE_TAG}"
+          value: "$(params.IQE_IMAGE_TAG)"
       runAfter:
         - deploy-application
       taskRef:


### PR DESCRIPTION
In https://github.com/RedHatInsights/bonfire-tekton/pull/51 I forgot to add IQE_IMAGE_TAG to pipelines/basic.yaml.

This change explicitly defines the IQE_IMAGE_TAG parameter for pass-down to deploy-iqe-cji.sh. Defaults to empty string.