### PR TITLE
Allow custom preparation step

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -128,6 +128,10 @@ spec:
       type: string
       description: "Tag of the iqe image to run tests from"
       default: ""
+    - name: CUSTOM_PREPARATION_TASK_NAME
+      type: string
+      description: "Custom preparation task to run before running the tests"
+      default: "noop"
   results:
     - name: ARTIFACTS_URL
       description: URL for the test's artifacts
@@ -209,6 +213,18 @@ spec:
             value: "$(params.REVISION)"
           - name: pathInRepo
             value: tasks/deploy.yaml
+    - name: custom-preparaion
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: "$(params.URL)"
+          - name: revision
+            value: "$(params.REVISION)"
+          - name: pathInRepo
+            value: tasks/$(params.CUSTOM_PREPARATION_TASK_NAME).yaml
+      runAfter:
+        - deploy-application
     - name: run-iqe-cji
       params:
         - name: BONFIRE_IMAGE
@@ -253,6 +269,7 @@ spec:
           value: "$(params.IQE_IMAGE_TAG)"
       runAfter:
         - deploy-application
+        - custom-preparaion
       taskRef:
         resolver: git
         params:

--- a/tasks/noop.yaml
+++ b/tasks/noop.yaml
@@ -1,0 +1,10 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: noop
+spec:
+  steps:
+    - name: noop-preparation
+      image: ubuntu
+      command: [echo]
+      args: ["No preparation step needed"]

--- a/tasks/preparation-provisioning.yaml
+++ b/tasks/preparation-provisioning.yaml
@@ -1,0 +1,16 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: noop
+spec:
+  params:
+    - name: BONFIRE_IMAGE
+      type: string
+      description: The container Bonfire image to use for the tekton tasks
+      default: quay.io/redhat-user-workloads/hcc-devprod-tenant/hcc-cicd-tools/cicd-tools:eb1904eafc2d8af8a26b435de393d4776d9db2f6
+  steps:
+    - name: stub-images-script
+      image: "$(params.BONFIRE_IMAGE)"
+      # TODO - figure out how to include the script.
+      script: |
+        echo "I could do something, but not sure how, but you get the point :)"


### PR DESCRIPTION
Add option to run a custom preparation step after application is deployed and before IQE tests run. This helps load fixtures in ephemeral environment, that are not static.

:warning: This is just an idea, I'd love to hear your thoughts before I finish it up.