### PR TITLE
Fix params passing syntax

### DIFF
--- a/tasks/run-iqe-cji.yaml
+++ b/tasks/run-iqe-cji.yaml
@@ -122,13 +122,13 @@ spec:
         - name: IQE_SELENIUM
           value: $(params.IQE_SELENIUM)
         - name: IQE_PARALLEL_ENABLED
-          value: ${params.IQE_PARALLEL_ENABLED}
+          value: $(params.IQE_PARALLEL_ENABLED)
         - name: IQE_PARALLEL_WORKER_COUNT
-          value: ${params.IQE_PARALLEL_WORKER_COUNT}
+          value: $(params.IQE_PARALLEL_WORKER_COUNT)
         - name: IQE_RP_ARGS
-          value: ${params.IQE_RP_ARGS}
+          value: $(params.IQE_RP_ARGS)
         - name: IQE_IBUTSU_SOURCE
-          value: ${params.IQE_IBUTSU_SOURCE}
+          value: $(params.IQE_IBUTSU_SOURCE)
         - name: BONFIRE_BOT
           value: "true"
         - name: IQE_IMAGE_TAG


### PR DESCRIPTION
23bdf2327de369355316b0b397bcc0505a618a60 (#17) has introduced wrong syntax for passing parameters. In 0106b8b13ad56b7690d57c518c67f5e5ee9f0e8f (#52) we've fixed it in pipeline definition, but not the task definition.